### PR TITLE
using conventions from text2qti

### DIFF
--- a/1-findable/quiz.md
+++ b/1-findable/quiz.md
@@ -1,8 +1,31 @@
-## 1) Which one of these is not a core aspect of FAIR?
-- Findable
-- Accessible
-- Identifiable
-- Reusable
+1. Which one of these is not a core aspect of FAIR?
+- [] Findable
+- [] Accessible
+- [*] Identifiable
+- [] Reusable
 
-Incorrect: Sorry, that is one of the core aspects of FAIR. You might like to visit the GO FAIR website.
-<p>Correct: Correct! Interoperability is a core aspect of the FAIR. The use of identifiers is common to Findability and Accessibility.
++   Correct! Interoperability is a core aspect of the FAIR. The use of identifiers is common to Findability and Accessibility.
+-   Sorry, that is one of the core aspects of FAIR. You might like to visit the GO FAIR website.
+
+2. Which of these are drivers of the FAIR guiding principles? Select all that apply
+- [*] To reduce the duplication of effort in producing research data
+- [*] To make it easier to verify the results of research
+- [*] To allow research data from different sources to be combined for new discoveries
+- [*] To extract the maximum benefit from research investment
+- [*] To make data easier to use for humans
+- [*] To make data easier to use for machines
+- [] To make sensitive data openly accessible
+- [] To force researchers to share research data
+
++   Yes, those are all drivers of the FAIR guiding principles.
+-   Sorry, your answer is not quite correct.
+
+3. In which discipline-focussed data repository can you find the data for Andrei Korostelev et al. (2007) Interactions and dynamics of the Shine–Dalgarno helix in the 70S ribosome,
+Proceedings of the National Academy of Sciences, 104 (43) 16840-16843; DOI: [10.1073/pnas.0707850104](https://doi.org/10.1073/pnas.0707850104)?
+
+- GenBank
+- *Protein Databank
+- AuScope Discovery Portal
+- Astrophysics Data System
+- [ICPSR](https://www.icpsr.umich.edu/web/pages/)
+

--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,0 +1,5 @@
+---
+  permalink: /researchdata/licence
+---
+
+With the exception of logos or where otherwise indicated, material in this repository is licensed with a [Creative Commons Attribution (CC BY) 4.0 licence](https://creativecommons.org/licenses/by/4.0/).


### PR DESCRIPTION
https://github.com/gpoore/text2qti has straightforward conventions for markdown which enable the file to be converted to QTI format for Canvas modules and other ed software. 
Proof of concept on 3 questions.